### PR TITLE
Re-add pushing to `ghcr.io`

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -68,5 +68,6 @@ jobs:
       with:
         context: .
         platforms: ${{env.platforms}}
+        push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Fix bug presented by `389ab30d54a306886508fc927e3896b5be580f73`, *always* push to `ghcr.io`